### PR TITLE
アイコンのチラつきを無くすため、Font Awesomeの設定を変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,5 +14,5 @@
  *= require_self
  */
 @import "reset";
-@import "bootstrap"; 
-@import '@fortawesome/fontawesome-free/scss/fontawesome';
+@import "bootstrap";
+@import "@fortawesome/fontawesome-free/scss/fontawesome";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,12 +6,12 @@
 //= require popper
 //= require bootstrap-sprockets
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
-require("jquery")
-require("./test.js")
+require("@rails/ujs").start();
+require("turbolinks").start();
+require("@rails/activestorage").start();
+require("channels");
+require("jquery");
+require("./test.js");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -20,6 +20,8 @@ require("./test.js")
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-import '@fortawesome/fontawesome-free/js/all';
-import 'bootstrap'
-import '../stylesheets/application.scss'
+import "@fortawesome/fontawesome-free/js/all";
+import "bootstrap";
+import "../stylesheets/application.scss";
+
+global.FontAwesome.config.mutateApproach = "sync";


### PR DESCRIPTION
### アイコンのチラつきを無くすため、Font Awesomeの設定を変更
- application.jsにglobal.FontAwesome.config.mutateApproach = "sync";　を追記