### PR TITLE
article_itemsテーブルのarticle_question_idのnull: falseを消去

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,13 +18,14 @@ class ArticlesController < ApplicationController
     if @article.save
       params[:items].each do |item|
         @article_item = @article.article_items.build(article_question_id: item[1][0], body: item[1][1])
-        @article_item.save
+        @article_item.save!
       end
       flash[:notice] = "新規投稿しました！"
       redirect_to articles_path
     else
-      render :new
-      flash.now[:notice] = "問いと内容を入力してください！"
+      respond_to do |format|
+        format.js { flash.now[:alert] = "タイトルを入力してください！" }
+      end
     end
   end
 

--- a/app/models/article_item.rb
+++ b/app/models/article_item.rb
@@ -7,7 +7,7 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  article_id          :bigint
-#  article_question_id :bigint           not null
+#  article_question_id :bigint
 #
 # Indexes
 #
@@ -20,6 +20,6 @@
 #  fk_rails_...  (article_question_id => article_questions.id)
 #
 class ArticleItem < ApplicationRecord
-  belongs_to :article_question
+  belongs_to :article_question, optional: true
   belongs_to :article
 end

--- a/app/views/articles/create.js.erb
+++ b/app/views/articles/create.js.erb
@@ -1,0 +1,6 @@
+/*フラッシュ*/
+<% if flash.now[:notice] %>
+  $("#flash").html(`<p class="alert alert-success mb-0"><%= flash.now[:notice] %></p>`)
+<% elsif flash.now[:alert] %>
+  $("#flash").html(`<p class="alert alert-danger mb-0"><%= flash[:alert] %></p>`)
+<% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -18,7 +18,11 @@
     <ul class="article-item-list">
       <% @article.article_items.each do |article_item| %>
         <li class="article-item-list__item">
-          <h5 class="card-title"><%= @article_questions.find(article_item.article_question_id).question %></h5>
+          <% if article_item.article_question_id != nil %>
+            <h5 class="card-title">問い：<%= @article_questions.find(article_item.article_question_id).question %></h5>
+          <% else %>
+            <h5 class="card-title">問いが選ばれていません</h5>
+          <% end %>
           <p class="card-text"><%=  article_item.body %></p>
         </li>
       <% end %>

--- a/db/migrate/20201103150641_add_article_question_id_to_article_items.rb
+++ b/db/migrate/20201103150641_add_article_question_id_to_article_items.rb
@@ -1,0 +1,5 @@
+class AddArticleQuestionIdToArticleItems < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :article_items, :article_question, foreign_key: true
+  end
+end

--- a/db/migrate/20201103150641_add_question_id_to_article_question.rb
+++ b/db/migrate/20201103150641_add_question_id_to_article_question.rb
@@ -1,5 +1,0 @@
-class AddQuestionIdToArticleQuestion < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :article_items, :article_question, null: false, foreign_key: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_150641) do
     t.bigint "article_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "article_question_id", null: false
+    t.bigint "article_question_id"
     t.index ["article_id"], name: "index_article_items_on_article_id"
     t.index ["article_question_id"], name: "index_article_items_on_article_question_id"
   end

--- a/spec/factories/article_items.rb
+++ b/spec/factories/article_items.rb
@@ -7,7 +7,7 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  article_id          :bigint
-#  article_question_id :bigint           not null
+#  article_question_id :bigint
 #
 # Indexes
 #

--- a/spec/features/articles_spec.rb
+++ b/spec/features/articles_spec.rb
@@ -250,50 +250,33 @@ RSpec.describe "Articles", js: true, type: :feature do
           expect(page).to have_current_path articles_path
         end
       end
+
+      context "タイトルを入力せず投稿しようとした時" do
+        it "フラッシュメッセージが表示される" do
+          visit new_article_path
+          click_on "投稿する"
+
+          expect(page).to have_content "タイトルを入力してください！"
+        end
+      end
+
+      context "問いを選ばずに投稿した場合" do
+        it "メモ詳細画面の問いの欄に「問いが選ばれていません」と表示される" do
+          visit new_article_path
+
+          fill_in "タイトル", with: "こんにちは"
+
+          fill_in "items[item1][]", with: "なぜこんにちはと言うのか？"
+          click_on "投稿する"
+
+          expect(page).to have_current_path articles_path, ignore_query: true
+
+          article = Article.find_by(title: "こんにちは")
+          visit article_path(article.id)
+
+          expect(page).to have_content "問いが選ばれていません"
+        end
+      end
     end
   end
-
-  # describe "カテゴリー別に分けられるか" do
-  #   before do
-  #     create(:satoshi, id: 1)
-
-  #     user = User.last
-  #     token = user.confirmation_token
-
-  #     visit user_confirmation_path(confirmation_token: token)
-
-  #     accept_confirm do
-  #       click_on "ログアウト"
-  #     end
-
-  #     create(:learn)
-  #     create(:impression)
-  #     create(:answer)
-  #     create(:other)
-  #     create(:learn_article, user_id: 1, category_id: 1)
-  #     create(:impression_article, user_id: 1, category_id: 2)
-  #     create(:answer_article, user_id: 1, category_id: 3)
-  #     create(:other_article, user_id: 1, category_id: 4)
-
-  #     visit new_user_session_path
-
-  #     fill_in "メールアドレス", with: "satoshi@example.com"
-  #     fill_in "パスワード", with: "satoshi1290"
-  #     click_button "ログイン"
-  #   end
-
-  #   it "カテゴリー分けできる" do
-  #     click_link "学び"
-  #     expect(page).to have_content "学び！"
-
-  #     click_link "感想"
-  #     expect(page).to have_content "感想！"
-
-  #     click_link "質問への回答"
-  #     expect(page).to have_content "質問への回答！"
-
-  #     click_link "その他"
-  #     expect(page).to have_content "その他！"
-  #   end
-  # end
 end

--- a/spec/models/article_item_spec.rb
+++ b/spec/models/article_item_spec.rb
@@ -7,7 +7,7 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  article_id          :bigint
-#  article_question_id :bigint           not null
+#  article_question_id :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
### article_itemsテーブルのarticle_question_idのnull: falseを消去
 - メモ詳細画面で問いが選択されていない時「問いが選ばれていません」と表示するように設定
 - メモが保存されなかった時、それまでの表示されていた文字が消えないように `articleのcreateメソッド` にajax通信を設定