### PR TITLE
Webpackerのエラーを解消するためのファイル削除

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,6 +21,7 @@ window.$ = $;
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
+
 import "@fortawesome/fontawesome-free/js/all";
 import "bootstrap";
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,0 @@
-@import "~bootstrap/scss/bootstrap";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@300&family=Pangolin&display=swap" rel="stylesheet">


### PR DESCRIPTION
herokuで`Webpacker can't find application.css`のエラーが出るため、
- `<%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>`を削除